### PR TITLE
Issue 12 - Claude auto-scheduling: time slot fitting

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 
 from models import Task, TaskUpdate, ChatRequest
 from prompts import SYSTEM_PROMPT
+from scheduling import build_schedule_context
 from database import (
     init_db,
     get_all_tasks,
@@ -219,6 +220,12 @@ async def chat(chat_request: ChatRequest) -> dict:
     if tasks:
         task_list = "\n".join([f"- {task.task_key}: {task.title}" for task in tasks if not task.completed])
         system_prompt += f"\n\nCurrent incomplete tasks:\n{task_list}"
+
+    # Add today's schedule context for auto-scheduling
+    today_tasks = get_tasks_for_date(today, today)
+    schedule_context = build_schedule_context(today_tasks)
+    if schedule_context:
+        system_prompt += schedule_context
 
     # Call Claude API
     try:

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -56,6 +56,13 @@ Priority estimation:
 - Otherwise, estimate based on the task description and context.
 - Default to 2 (Medium) if truly uncertain.
 
+Auto-scheduling (for tasks created for today without a specific time):
+- After estimating duration, if the task is for today and the user has not specified a time, assign a start time.
+- Use "Today's schedule" and "Available business-hours gaps" provided below to avoid conflicts.
+- Find the first available gap large enough for the estimated duration.
+- If no gap fits within business hours, set scheduled_date to today's date only (YYYY-MM-DD, no time) — the task will appear as unscheduled.
+- Otherwise, set scheduled_date to YYYY-MM-DDTHH:MM with the chosen start time.
+
 Respond with this exact JSON format:
 {{
     "operation": "create" | "update" | "delete",

--- a/backend/scheduling.py
+++ b/backend/scheduling.py
@@ -1,0 +1,68 @@
+"""
+Scheduling utilities for auto-assigning time slots.
+Builds schedule context for the system prompt.
+"""
+from models import Task
+
+
+def build_schedule_context(tasks: list[Task]) -> str:
+    """
+    Build today's schedule context string for the system prompt.
+
+    tasks: today's tasks (as returned by get_tasks_for_date)
+
+    Returns a formatted string with scheduled tasks and available business-hours
+    gaps (09:00-17:00), or empty string if no tasks have a specific time.
+    Assumes: scheduled_date is YYYY-MM-DDTHH:MM when a time is present.
+    """
+    # Only include incomplete tasks that have a specific time
+    timed = [
+        t for t in tasks
+        if t.scheduled_date and "T" in t.scheduled_date and not t.completed
+    ]
+    if not timed:
+        return ""
+
+    timed.sort(key=lambda t: t.scheduled_date)
+
+    BIZ_START = 9 * 60   # 09:00 in minutes
+    BIZ_END = 17 * 60    # 17:00 in minutes
+
+    booked = []
+    lines = []
+    for task in timed:
+        time_str = task.scheduled_date.split("T")[1]  # HH:MM
+        h, m = map(int, time_str.split(":"))
+        start_min = h * 60 + m
+        duration = task.duration_minutes or 15  # consistent with create_task_db default
+        end_min = start_min + duration
+        end_h, end_m = divmod(end_min, 60)
+        lines.append(
+            f"  {task.task_key}: {task.title} ({time_str}-{end_h:02d}:{end_m:02d}, {duration}min)"
+        )
+        booked.append((start_min, end_min))
+
+    # Clip booked intervals to business hours and compute gaps
+    clipped = []
+    for start, end in booked:
+        s = max(start, BIZ_START)
+        e = min(end, BIZ_END)
+        if s < e:
+            clipped.append((s, e))
+    clipped.sort()
+
+    gaps = []
+    prev_end = BIZ_START
+    for start, end in clipped:
+        if start > prev_end:
+            g_sh, g_sm = divmod(prev_end, 60)
+            g_eh, g_em = divmod(start, 60)
+            gaps.append(f"{g_sh:02d}:{g_sm:02d}-{g_eh:02d}:{g_em:02d}")
+        prev_end = max(prev_end, end)
+    if prev_end < BIZ_END:
+        g_sh, g_sm = divmod(prev_end, 60)
+        gaps.append(f"{g_sh:02d}:{g_sm:02d}-17:00")
+
+    schedule_str = "\n".join(lines)
+    gaps_str = ", ".join(gaps) if gaps else "none"
+    return f"\nToday's schedule:\n{schedule_str}\nAvailable business-hours gaps: {gaps_str}"

--- a/backend/tests/test_scheduling.py
+++ b/backend/tests/test_scheduling.py
@@ -1,0 +1,114 @@
+"""
+Tests for build_schedule_context() in scheduling.py.
+Tests gap calculation and schedule formatting for auto-scheduling.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models import Task
+from scheduling import build_schedule_context
+
+
+def _task(task_key, title, scheduled_date, duration_minutes=30, completed=False):
+    # Assumes: task_key format is CATEGORY-NN, scheduled_date is YYYY-MM-DD or YYYY-MM-DDTHH:MM
+    return Task(
+        id="test-id",
+        task_key=task_key,
+        category=task_key[0],
+        task_number=1,
+        title=title,
+        scheduled_date=scheduled_date,
+        duration_minutes=duration_minutes,
+        created_at="2026-02-22T00:00:00",
+        completed=completed,
+    )
+
+
+class TestBuildScheduleContext:
+
+    def test_empty_list_returns_empty(self):
+        assert build_schedule_context([]) == ""
+
+    def test_no_timed_tasks_returns_empty(self):
+        tasks = [
+            _task("T-01", "Review docs", "2026-02-22"),
+            _task("T-02", "No date task", None),
+        ]
+        assert build_schedule_context(tasks) == ""
+
+    def test_completed_timed_task_excluded(self):
+        tasks = [_task("M-01", "Standup", "2026-02-22T09:00", 30, completed=True)]
+        assert build_schedule_context(tasks) == ""
+
+    def test_single_timed_task_format(self):
+        tasks = [_task("M-01", "Standup", "2026-02-22T09:00", 30)]
+        result = build_schedule_context(tasks)
+        assert "M-01: Standup (09:00-09:30, 30min)" in result
+        assert "Available business-hours gaps:" in result
+        # Gap after standup within business hours
+        assert "09:30-17:00" in result
+        # No gap before 09:00 (business hours start at 09:00)
+        assert "00:00" not in result
+
+    def test_two_tasks_with_gap_between(self):
+        tasks = [
+            _task("M-01", "Standup", "2026-02-22T09:00", 30),
+            _task("T-03", "Code review", "2026-02-22T10:00", 60),
+        ]
+        result = build_schedule_context(tasks)
+        assert "M-01: Standup (09:00-09:30, 30min)" in result
+        assert "T-03: Code review (10:00-11:00, 60min)" in result
+        assert "09:30-10:00" in result
+        assert "11:00-17:00" in result
+        # No gap before business hours
+        assert "00:00" not in result
+
+    def test_adjacent_tasks_no_gap_between_them(self):
+        tasks = [
+            _task("M-01", "Meeting A", "2026-02-22T09:00", 60),
+            _task("M-02", "Meeting B", "2026-02-22T10:00", 60),
+        ]
+        result = build_schedule_context(tasks)
+        # No gap between adjacent meetings
+        assert "09:00-10:00" not in result
+        # Gap after both meetings
+        assert "11:00-17:00" in result
+
+    def test_task_outside_business_hours_does_not_create_biz_gap(self):
+        # Task before business hours — should not show up as a gap
+        tasks = [_task("M-01", "Early meeting", "2026-02-22T07:00", 60)]
+        result = build_schedule_context(tasks)
+        # Full business hours should be available since task is before 09:00
+        assert "09:00-17:00" in result
+
+    def test_task_overlapping_start_of_business_hours(self):
+        # Task 08:00-09:30 eats into first 30min of business hours
+        tasks = [_task("M-01", "Early overlap", "2026-02-22T08:00", 90)]
+        result = build_schedule_context(tasks)
+        # Gap starts at 09:30 (where the task ends within biz hours)
+        assert "09:30-17:00" in result
+        assert "09:00-" not in result
+
+    def test_full_business_hours_booked_shows_no_gaps(self):
+        tasks = [_task("M-01", "All day", "2026-02-22T09:00", 480)]  # 9:00-17:00
+        result = build_schedule_context(tasks)
+        assert "Available business-hours gaps: none" in result
+
+    def test_none_duration_falls_back_to_default(self):
+        tasks = [_task("T-01", "Task", "2026-02-22T10:00", None)]
+        result = build_schedule_context(tasks)
+        # Should not crash; default is 15min
+        assert "10:00-10:15" in result
+
+    def test_tasks_sorted_by_time(self):
+        # Create tasks out of order
+        tasks = [
+            _task("M-02", "Later meeting", "2026-02-22T11:00", 30),
+            _task("M-01", "Earlier meeting", "2026-02-22T09:00", 30),
+        ]
+        result = build_schedule_context(tasks)
+        earlier_pos = result.index("M-01")
+        later_pos = result.index("M-02")
+        assert earlier_pos < later_pos


### PR DESCRIPTION
## Closes [#12](https://github.com/therogue/tskr/issues/12). Depends on #11 (duration estimation).

### Description

When a user creates a task for today without specifying a time, Claude now auto-assigns a non-overlapping start time within business hours (09:00–17:00). If no gap fits, the task is left unscheduled (date-only).

### Changes

- `scheduling.py` (new) — build_schedule_context(tasks): computes today's timed tasks and available business-hours gaps
- `main.py `— injects schedule context into the system prompt on each /chat request
- `prompts.py` — instructs Claude to use the schedule context when assigning start times
- `tests/test_scheduling.py` (new) — unit tests for gap calculation logic

### Screenshot

<img width="710" height="194" alt="Screen Shot 2026-02-22 at 3 22 15 PM" src="https://github.com/user-attachments/assets/dc466ac4-f30c-40d4-a63a-eb81bbe55ef6" />
