### PR TITLE
Issue 16: Added Backlog View and refactored task handling to show unscheduled tasks for the day in the Backlog. 

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -318,11 +318,8 @@ def get_tasks_for_date(target_date: str, today: str) -> list[Task]:
             result.append(task)
             continue
 
-        if is_today and not scheduled:
-            result.append(task)
-            continue
-
-        # Overdue non-recurrent tasks (recurrent instances excluded — each day gets its own)
+        # For today only: include incomplete non-recurrent tasks with past scheduled_date (overdue)
+        # Recurrent instances (parent_task_id set) are excluded — each day gets its own instance
         if is_today and scheduled_date_only and scheduled_date_only < today and not task.completed and not task.parent_task_id:
             result.append(task)
             continue

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -8,7 +8,7 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from database import create_task_db, get_all_tasks
+from database import create_task_db, get_all_tasks, get_tasks_for_date
 from prompts import SYSTEM_PROMPT
 
 
@@ -68,3 +68,33 @@ class TestSystemPromptTaskContext:
     def test_system_prompt_mentions_task_context(self, test_db):
         """System prompt mentions task list will be provided."""
         assert "task_key" in SYSTEM_PROMPT.lower() or "current tasks" in SYSTEM_PROMPT.lower()
+
+
+class TestDayViewExcludesUnscheduledTasks:
+    """Unscheduled tasks must not appear in day view (Issue #16)."""
+
+    def test_unscheduled_task_excluded_from_today(self, test_db):
+        """Tasks with no scheduled_date do not appear in get_tasks_for_date for today."""
+        today = "2026-02-23"
+        create_task_db("id-unscheduled", "Unscheduled task", "T")
+
+        result = get_tasks_for_date(today, today)
+        ids = [t.id for t in result]
+        assert "id-unscheduled" not in ids
+
+    def test_scheduled_task_appears_in_day_view(self, test_db):
+        """Tasks with a matching scheduled_date still appear in day view."""
+        today = "2026-02-23"
+        create_task_db("id-scheduled", "Scheduled task", "T", today)
+
+        result = get_tasks_for_date(today, today)
+        ids = [t.id for t in result]
+        assert "id-scheduled" in ids
+
+    def test_unscheduled_task_appears_in_get_all_tasks(self, test_db):
+        """Unscheduled tasks are still returned by get_all_tasks (for backlog tab)."""
+        create_task_db("id-backlog", "Backlog task", "T")
+
+        all_tasks = get_all_tasks()
+        ids = [t.id for t in all_tasks]
+        assert "id-backlog" in ids

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ interface Task {
   projected?: boolean
 }
 
-type ViewMode = 'day' | 'all' | 'completed'
+type ViewMode = 'day' | 'all' | 'completed' | 'backlog'
 
 const API_URL = 'http://localhost:8000'
 

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -16,7 +16,7 @@ interface Task {
   priority: number | null  // 0=None, 1=Low, 2=Medium, 3=High, 4=Critical
 }
 
-type ViewMode = 'day' | 'all' | 'completed'
+type ViewMode = 'day' | 'all' | 'completed' | 'backlog'
 type DayViewMode = 'list' | 'calendar'
 
 interface TaskListProps {
@@ -589,6 +589,47 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
     )
   }
 
+  function renderBacklogView() {
+    const meetings = tasks.filter(t =>
+      t.category === 'M' && !t.is_template && !t.completed && !t.scheduled_date
+    )
+    const regularTasks = tasks.filter(t =>
+      t.category === 'T' && !t.is_template && !t.completed && !t.scheduled_date
+    )
+    const projectTasks = tasks.filter(t =>
+      !t.is_template && !['M', 'T', 'D'].includes(t.category) && !t.completed && !t.scheduled_date
+    )
+    const projectCategories = [...new Set(projectTasks.map(t => t.category))].sort()
+
+    const isEmpty = meetings.length === 0 && regularTasks.length === 0 && projectTasks.length === 0
+    const ordered: Task[] = [
+      ...meetings,
+      ...regularTasks,
+      ...projectCategories.flatMap(cat => projectTasks.filter(t => t.category === cat)),
+    ]
+    orderedVisibleTasksRef.current = ordered
+
+    let sectionStart = 0
+    return (
+      <>
+        {isEmpty ? (
+          <p className="empty-state">No backlog tasks.</p>
+        ) : (
+          <>
+            {renderSection('Meetings', meetings, true, sectionStart)}
+            {renderSection('Tasks', regularTasks, true, sectionStart += meetings.length)}
+            {projectCategories.map(cat => {
+              const catTasks = projectTasks.filter(t => t.category === cat)
+              const si = sectionStart
+              sectionStart += catTasks.length
+              return renderSection(cat, catTasks, true, si)
+            })}
+          </>
+        )}
+      </>
+    )
+  }
+
   return (
     <div className="task-panel">
       <div className="tab-bar">
@@ -609,6 +650,12 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
           onClick={() => onViewModeChange('completed')}
         >
           Completed
+        </button>
+        <button
+          className={`tab ${viewMode === 'backlog' ? 'active' : ''}`}
+          onClick={() => onViewModeChange('backlog')}
+        >
+          Backlog
         </button>
       </div>
 
@@ -633,6 +680,7 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
         {viewMode === 'day' && renderDayView()}
         {viewMode === 'all' && renderAllTasksView(false)}
         {viewMode === 'completed' && renderAllTasksView(true)}
+        {viewMode === 'backlog' && renderBacklogView()}
       </div>
     </div>
   )


### PR DESCRIPTION
Changelog:
----

- Removed the inclusion of unscheduled tasks in the `get_tasks_for_date` function for today's view.
- Updated database schema to add `duration_minutes` and `priority` fields to tasks.
- Introduced a new backlog view in the frontend to display unscheduled tasks, with appropriate filtering and rendering logic.
- Added tests to ensure unscheduled tasks are excluded from today's view while still being retrievable in the backlog and all tasks views.
- Updated conftest.py to fix issues with the tests, along with several other tests.

Issues:
---
Closes #16.

Screenshots:
-----
<img width="553" height="277" alt="image" src="https://github.com/user-attachments/assets/e64e08ce-ad31-43cb-ab7f-20485b720b66" />
<img width="1113" height="719" alt="image" src="https://github.com/user-attachments/assets/94c56e35-b657-47e3-be59-5520bb331736" />
<img width="1106" height="719" alt="image" src="https://github.com/user-attachments/assets/39c7af75-2562-4741-b279-0fd920f3cbd6" />

