### PR TITLE
Issue 56 - Spotlight-Style Quick-Entry Popup for Task Creation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,7 +5,7 @@
 }
 
 body {
-  font-family: 'Manrope', sans-serif;
+  font-family: "Manrope", sans-serif;
   background: #0d1b2a;
   color: #e8e8e8;
 }
@@ -234,7 +234,9 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
   cursor: pointer;
 }
 .task-item.selected {
@@ -288,7 +290,9 @@ body {
   align-items: center;
   justify-content: center;
   opacity: 0;
-  transition: opacity 0.2s ease, color 0.15s ease;
+  transition:
+    opacity 0.2s ease,
+    color 0.15s ease;
 }
 
 .task-item:hover .task-delete-btn,
@@ -450,7 +454,9 @@ body {
   gap: 4px;
   font-size: 0.8rem;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 .calendar-task-block.selected {
   border: 2px solid #6b8cce;
@@ -1225,4 +1231,61 @@ body {
 
 .settings-unsaved-keep-btn:hover {
   background: #6b8cce;
+}
+
+/* Quick Entry (Spotlight-style popup) */
+.quick-entry-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 20vh;
+}
+
+.quick-entry-popup {
+  background: #152238;
+  border: 1px solid #3a4f6f;
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+  width: 520px;
+  max-width: calc(100vw - 2rem);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.quick-entry-input {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  background: #1b2838;
+  border: 1px solid #3a4f6f;
+  border-radius: 8px;
+  color: #e8e8e8;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.quick-entry-input::placeholder {
+  color: #607080;
+}
+
+.quick-entry-input:focus {
+  outline: none;
+  border-color: #6b8cce;
+}
+
+.quick-entry-feedback {
+  font-size: 0.82rem;
+  color: #a0b0c0;
+  padding: 0 0.25rem;
+}
+
+.quick-entry-hint {
+  font-size: 0.72rem;
+  color: #4a5a6a;
+  padding: 0 0.25rem;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,38 +2,40 @@ import { useState, useEffect } from 'react'
 import TaskList from './components/TaskList'
 import ChatInterface from './components/ChatInterface'
 import SettingsModal from './components/SettingsModal'
+import QuickEntry from './components/QuickEntry'
 
 // Assumption: Task matches backend Task model, with optional projected field
 interface Task {
-  id: string
-  task_key: string
-  category: string
-  task_number: number
-  title: string
-  completed: boolean
-  scheduled_date: string | null  // YYYY-MM-DD or YYYY-MM-DDTHH:MM
-  recurrence_rule: string | null
-  created_at: string
-  is_template: boolean
-  parent_task_id: string | null
-  duration_minutes: number | null
-  priority: number | null  // 0=None, 1=Low, 2=Medium, 3=High, 4=Critical
-  projected?: boolean
+  id: string;
+  task_key: string;
+  category: string;
+  task_number: number;
+  title: string;
+  completed: boolean;
+  scheduled_date: string | null; // YYYY-MM-DD or YYYY-MM-DDTHH:MM
+  recurrence_rule: string | null;
+  created_at: string;
+  is_template: boolean;
+  parent_task_id: string | null;
+  duration_minutes: number | null;
+  priority: number | null; // 0=None, 1=Low, 2=Medium, 3=High, 4=Critical
+  projected?: boolean;
 }
 
-type ViewMode = 'day' | 'all' | 'completed' | 'backlog'
+type ViewMode = "day" | "all" | "completed" | "backlog";
 
-const API_URL = 'http://localhost:8000'
+const API_URL = "http://localhost:8000";
 
 // Helper to format Date to YYYY-MM-DD
 function formatDateStr(date: Date): string {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
 function App() {
-  const [tasks, setTasks] = useState<Task[]>([])
-  const [viewMode, setViewMode] = useState<ViewMode>('day')
-  const [showSettings, setShowSettings] = useState(false)
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>('day');
+  const [showSettings, setShowSettings] = useState(false);
+  const [quickEntryOpen, setQuickEntryOpen] = useState(false);
   
   const CHAT_COLLAPSED_KEY = 'chatCollapsed'
   const [chatCollapsed, setChatCollapsed] = useState<boolean>(() => {
@@ -49,30 +51,43 @@ function App() {
   }
 
   // Get today's date in YYYY-MM-DD format
-  const todayStr = formatDateStr(new Date())
-  const [selectedDate, setSelectedDate] = useState<string>(todayStr)
+  const todayStr = formatDateStr(new Date());
+  const [selectedDate, setSelectedDate] = useState<string>(todayStr);
+
+  // Ctrl+. / Cmd+. opens quick entry
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "." && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        setQuickEntryOpen((prev) => !prev);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   useEffect(() => {
-    fetchTasks()
-  }, [viewMode, selectedDate])
+    fetchTasks();
+  }, [viewMode, selectedDate]);
 
   async function fetchTasks() {
     try {
       // Day view uses date-specific endpoint, others use /tasks
-      const url = viewMode === 'day'
-        ? `${API_URL}/tasks/for-date?date=${selectedDate}`
-        : `${API_URL}/tasks`
-      const res = await fetch(url)
-      const data = await res.json()
-      setTasks(data)
+      const url =
+        viewMode === "day"
+          ? `${API_URL}/tasks/for-date?date=${selectedDate}`
+          : `${API_URL}/tasks`;
+      const res = await fetch(url);
+      const data = await res.json();
+      setTasks(data);
     } catch (err) {
-      console.error('Failed to fetch tasks:', err)
+      console.error("Failed to fetch tasks:", err);
     }
   }
 
   function handleTasksUpdate() {
     // Refetch tasks after any update
-    fetchTasks()
+    fetchTasks();
   }
 
   return (
@@ -104,8 +119,14 @@ function App() {
         />
         <ChatInterface onTasksUpdate={handleTasksUpdate} collapsed={chatCollapsed} onToggleCollapse={handleToggleChat} />
       </main>
+      {quickEntryOpen && (
+        <QuickEntry
+          onClose={() => setQuickEntryOpen(false)}
+          onTasksUpdate={handleTasksUpdate}
+        />
+      )}
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/QuickEntry.tsx
+++ b/frontend/src/components/QuickEntry.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect, useRef } from "react";
+
+interface QuickEntryProps {
+  onClose: () => void;
+  onTasksUpdate: () => void;
+}
+
+const API_URL = "http://localhost:8000";
+
+function QuickEntry({ onClose, onTasksUpdate }: QuickEntryProps) {
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  function handleOverlayClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === overlayRef.current) onClose();
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || loading) return;
+
+    setLoading(true);
+    setFeedback(null);
+    try {
+      const convRes = await fetch(`${API_URL}/conversation/new`, {
+        method: "POST",
+      });
+      const convData = await convRes.json();
+      const conversationId: number = convData.id;
+
+      const res = await fetch(`${API_URL}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: text }],
+          conversation_id: conversationId,
+        }),
+      });
+      const data = await res.json();
+      onTasksUpdate();
+      setFeedback(data.response ?? "Done");
+      setInput("");
+      // Auto-close after brief feedback delay
+      setTimeout(onClose, 3000);
+    } catch {
+      setFeedback("Error connecting to server");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      className="quick-entry-overlay"
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+    >
+      <div className="quick-entry-popup">
+        <form onSubmit={handleSubmit}>
+          <input
+            ref={inputRef}
+            className="quick-entry-input"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Create a task..."
+            disabled={loading}
+          />
+        </form>
+        {feedback && <div className="quick-entry-feedback">{feedback}</div>}
+        <div className="quick-entry-hint">Enter to submit · Esc to dismiss</div>
+      </div>
+    </div>
+  );
+}
+
+export default QuickEntry;


### PR DESCRIPTION
## Summary

Closes Issue #56

Sub-Task of Parent Issue #50

Adds a Spotlight-style floating input popup for instant task creation from anywhere in the app.

- `Ctrl+.` / `Cmd+.` opens a centered overlay input (cross-platform, browser-safe shortcut)
- Dismissible via `Escape` or clicking outside the popup
- Submits to `/chat` via a new conversation (same backend endpoint as the chat panel)
- Available from all views: day, backlog, completed
- Shows the assistant's response for 3 seconds before auto-closing

## Test plan

- [x] Press `Ctrl+.` (Windows/Linux) or `Cmd+.` (Mac) — popup opens
- [x] Press `Escape` — popup closes
- [x] Click outside the popup — popup closes
- [x] Type a task and press `Enter` — task is created, feedback shown, popup closes after 3s
- [x] Verify the exchange appears as a new conversation in chat history
- [x] Verify the task list refreshes after submission
- [x] Test from day view, backlog view, and completed view

🤖 Generated with [Claude Code](https://claude.com/claude-code)