### PR TITLE
Issue 55: Collabsible, Minimizable Conversation Panel

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -124,6 +124,7 @@ body {
   display: flex;
   border-bottom: 1px solid #2a3f5f;
   background: #152238;
+  min-height: 2.75rem;
 }
 
 .tab {
@@ -135,6 +136,8 @@ body {
   cursor: pointer;
   font-size: 0.85rem;
   font-weight: 500;
+  display: inline-flex;
+  align-items: center;
 }
 
 .tab:hover {
@@ -169,6 +172,9 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .date-nav-btn:hover {
@@ -527,10 +533,35 @@ body {
 
 /* Chat Panel */
 .chat-panel {
-  flex: 1;
+  flex: 0 0 50%;
   background: #1b2838;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  transition: flex-basis 0.3s ease;
+}
+
+.chat-panel.collapsed {
+  flex-basis: 36px;
+}
+
+.chat-panel .chat-header h2,
+.chat-panel .chat-header-actions {
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+.chat-panel.collapsed .chat-header h2,
+.chat-panel.collapsed .chat-header-actions {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.chat-panel.collapsed .chat-messages,
+.chat-panel.collapsed .chat-input-form {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .chat-header {
@@ -539,6 +570,27 @@ body {
   justify-content: space-between;
   padding: 0.5rem;
   border-bottom: 1px solid #2a3f5f;
+  flex-shrink: 0;
+  min-height: 2.75rem;
+}
+
+.chat-collapse-btn {
+  padding: 0.25rem 0.5rem;
+  background: #253545;
+  color: #a0b0c0;
+  border: 1px solid #3a4f6f;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.chat-collapse-btn:hover {
+  background: #3a4f6f;
+  color: #e8e8e8;
 }
 
 .chat-header h2 {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,19 @@ function App() {
   const [tasks, setTasks] = useState<Task[]>([])
   const [viewMode, setViewMode] = useState<ViewMode>('day')
   const [showSettings, setShowSettings] = useState(false)
+  
+  const CHAT_COLLAPSED_KEY = 'chatCollapsed'
+  const [chatCollapsed, setChatCollapsed] = useState<boolean>(() => {
+    return localStorage.getItem(CHAT_COLLAPSED_KEY) === 'true'
+  })
+
+  function handleToggleChat() {
+    setChatCollapsed(prev => {
+      const next = !prev
+      localStorage.setItem(CHAT_COLLAPSED_KEY, String(next))
+      return next
+    })
+  }
 
   // Get today's date in YYYY-MM-DD format
   const todayStr = formatDateStr(new Date())
@@ -89,7 +102,7 @@ function App() {
           onDateChange={setSelectedDate}
           onTasksUpdate={handleTasksUpdate}
         />
-        <ChatInterface onTasksUpdate={handleTasksUpdate} />
+        <ChatInterface onTasksUpdate={handleTasksUpdate} collapsed={chatCollapsed} onToggleCollapse={handleToggleChat} />
       </main>
     </div>
   )

--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 
 interface ChatInterfaceProps {
   onTasksUpdate: () => void
+  collapsed: boolean
+  onToggleCollapse: () => void
 }
 
 interface Message {
@@ -22,7 +24,7 @@ interface HistoryPopup {
 
 const API_URL = 'http://localhost:8000'
 
-function ChatInterface({ onTasksUpdate }: ChatInterfaceProps) {
+function ChatInterface({ onTasksUpdate, collapsed, onToggleCollapse }: ChatInterfaceProps) {
   const [messages, setMessages] = useState<Message[]>([])
   const [activeConversationId, setActiveConversationId] = useState<number | null>(null)
   const [input, setInput] = useState('')
@@ -144,8 +146,16 @@ function ChatInterface({ onTasksUpdate }: ChatInterfaceProps) {
   }
 
   return (
-    <div className="chat-panel">
+    <div className={`chat-panel${collapsed ? ' collapsed' : ''}`}>
       <div className="chat-header">
+        <button
+          className="chat-collapse-btn"
+          onClick={onToggleCollapse}
+          title={collapsed ? 'Expand chat' : 'Collapse chat'}
+          type="button"
+        >
+          {collapsed ? '<' : '>'}
+        </button>
         <h2>Chat</h2>
         <div className="chat-header-actions">
           <button


### PR DESCRIPTION
## Summary

Closes Issue #55

Sub-Task of Parent Issue #50

- Adds a `>` / `<` toggle button to the chat panel header that collapses/expands the panel with an animated `flex-basis` transition
- Collapsed state persists across page reloads via `localStorage`
- Task panel fills reclaimed space automatically via `flex: 1`
- Header title and actions fade out during collapse to avoid jarring instant-disappear

## Changes

- `App.tsx` — `chatCollapsed` state (lazy-initialised from `localStorage`), `handleToggleChat`, both passed as props to `ChatInterface`
- `ChatInterface.tsx` — `collapsed`/`onToggleCollapse` props; collapse button in header; `.collapsed` class on panel root
- `App.css` — `flex-basis` transition on `.chat-panel`; `.collapsed` override; opacity fade on header content; `.chat-collapse-btn` styles matching `.date-nav-btn`; `min-height: 2.75rem` to align task and chat panel headers; flex centering on `.tab` and `.date-nav-btn`

## Test plan

- [x] Click `>` in chat header — panel animates closed, task panel expands
- [x] Click `<` — panel animates open
- [x] Collapse, reload page — panel stays collapsed
- [x] Expand, reload page — panel stays expanded
- [x] Animation is smooth with no layout jumps

## Screenshots

**Expanded Chat View**

<img width="1293" height="850" alt="hakadorio-issue-55-expanded-chat-view" src="https://github.com/user-attachments/assets/377a7a2c-4707-47be-9887-5f58af8e16cd" />

**Collapsed Chat View**

<img width="1295" height="847" alt="hakadorio-issue-55-collapsed-chat-view" src="https://github.com/user-attachments/assets/b11a0aa3-273b-4cb9-9fe2-66a4e715a57a" />

🤖 Solution created with the help of [Claude Code](https://claude.com/claude-code)
