### PR TITLE
Issue 48 - Enhance task management with drag-and-drop functionality and rescheduling popup

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -404,6 +404,64 @@ body {
   border-color: #ff6b6b;
 }
 
+.day-view-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.reschedule-selected-btn {
+  padding: 0.25rem 0.75rem;
+  background: transparent;
+  color: #6b8cce;
+  border: 1px solid #6b8cce;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.reschedule-selected-btn:hover {
+  background: rgba(107, 140, 206, 0.15);
+  color: #8aaae0;
+  border-color: #8aaae0;
+}
+
+.reschedule-popup {
+  min-width: 220px;
+}
+
+.reschedule-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.reschedule-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.75rem;
+  color: #8090a0;
+}
+
+.reschedule-input {
+  background: #0d1b2a;
+  border: 1px solid #2a3f5f;
+  border-radius: 4px;
+  color: #e8e8e8;
+  padding: 0.25rem 0.4rem;
+  font-size: 0.8rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.reschedule-input:focus {
+  outline: none;
+  border-color: #6b8cce;
+}
+
 /* Calendar View */
 .calendar-unscheduled {
   margin-bottom: 1rem;
@@ -453,10 +511,17 @@ body {
   align-items: flex-start;
   gap: 4px;
   font-size: 0.8rem;
-  cursor: pointer;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
+  cursor: grab;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-task-block.dragging {
+  cursor: grabbing;
+  opacity: 0.75;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  z-index: 50;
+  border-color: #6b8cce;
+  transition: none; /* disable transition during drag for responsiveness */
 }
 .calendar-task-block.selected {
   border: 2px solid #6b8cce;

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { computeColumnLayout, DEFAULT_DURATION } from '../utils/calendarLayout'
+import { computeColumnLayout, DEFAULT_DURATION, pxToSnappedMinutes, minutesToTimeStr } from '../utils/calendarLayout'
 
 interface Task {
   id: string
@@ -115,6 +115,27 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
   const orderedVisibleTasksRef = useRef<Task[]>([])
   const [confirmDelete, setConfirmDelete] = useState<{ message: string; ids: string[]; x: number; y: number } | null>(null)
 
+  // Drag state: stored in ref to avoid re-renders on every pointermove
+  interface DragData {
+    taskId: string
+    element: HTMLElement
+    startClientY: number
+    startTopPx: number
+    currentTopPx: number
+    hasMoved: boolean
+    // For group drag: other selected task ids → their original top px
+    groupOrigTops: Map<string, number>
+  }
+  const dragStateRef = useRef<DragData | null>(null)
+  const dragJustFinishedRef = useRef(false)
+  const [draggingTaskId, setDraggingTaskId] = useState<string | null>(null)
+  // Map of task id → calendar block DOM element, for group drag visual
+  const taskBlockRefsMap = useRef<Map<string, HTMLElement>>(new Map())
+
+  // Bulk reschedule popup
+  const [reschedulePopup, setReschedulePopup] = useState<{ x: number; y: number } | null>(null)
+  const [rescheduleDate, setRescheduleDate] = useState<string>('')
+
   // Auto-scroll calendar to ~8am when switching to calendar view
   useEffect(() => {
     if (dayViewMode === 'calendar' && calendarRef.current) {
@@ -211,6 +232,163 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
       })
       lastClickedIndexRef.current = indexInOrdered
     }
+  }
+
+  function handleDragStart(e: React.PointerEvent, task: Task, startTopPx: number) {
+    // Only drag timed tasks; ignore clicks on interactive children
+    if (!task.scheduled_date?.includes('T')) return
+    if ((e.target as HTMLElement).closest('.task-checkbox, .task-delete-btn')) return
+    // Do NOT call e.preventDefault() here — it would suppress the subsequent click
+    // event and break task selection. Text selection is prevented in handleDragMove
+    // once the movement threshold is crossed.
+
+    const el = e.currentTarget as HTMLElement
+    el.setPointerCapture(e.pointerId)
+
+    // Precompute original top positions for other selected timed tasks (group drag)
+    const groupOrigTops = new Map<string, number>()
+    if (selectedIds.has(task.id) && selectedIds.size > 1) {
+      for (const id of selectedIds) {
+        if (id === task.id) continue
+        const t = tasks.find(t => t.id === id)
+        if (t?.scheduled_date?.includes('T')) {
+          const timePart = t.scheduled_date.slice(11, 16)
+          const [h, m] = timePart.split(':').map(Number)
+          groupOrigTops.set(id, h * HOUR_HEIGHT + m * (HOUR_HEIGHT / 60))
+        }
+      }
+    }
+
+    dragStateRef.current = {
+      taskId: task.id,
+      element: el,
+      startClientY: e.clientY,
+      startTopPx,
+      currentTopPx: startTopPx,
+      hasMoved: false,
+      groupOrigTops,
+    }
+  }
+
+  function handleDragMove(e: React.PointerEvent) {
+    const ds = dragStateRef.current
+    if (!ds || ds.taskId !== (e.currentTarget as HTMLElement).dataset.taskId) return
+
+    const deltaY = e.clientY - ds.startClientY
+    if (!ds.hasMoved && Math.abs(deltaY) < 5) return
+
+    // Prevent text selection and scroll during drag (safe here — pointermove
+    // preventDefault does NOT suppress the click event, unlike pointerdown)
+    e.preventDefault()
+
+    if (!ds.hasMoved) {
+      ds.hasMoved = true
+      setDraggingTaskId(ds.taskId)
+    }
+
+    const rawTop = ds.startTopPx + deltaY
+    const snappedMinutes = pxToSnappedMinutes(rawTop)
+    ds.currentTopPx = snappedMinutes // 1px == 1 minute
+    ds.element.style.top = `${snappedMinutes}px`
+
+    // Move other selected tasks by the same raw delta
+    for (const [id, origTop] of ds.groupOrigTops) {
+      const otherEl = taskBlockRefsMap.current.get(id)
+      if (otherEl) otherEl.style.top = `${pxToSnappedMinutes(origTop + deltaY)}px`
+    }
+  }
+
+  async function handleDragEnd(e: React.PointerEvent, task: Task) {
+    const ds = dragStateRef.current
+    if (!ds || ds.taskId !== task.id) return
+
+    const wasDragging = ds.hasMoved
+    dragStateRef.current = null
+    setDraggingTaskId(null)
+
+    if (!wasDragging) return
+
+    // Suppress the click that fires after pointerup
+    dragJustFinishedRef.current = true
+
+    const snappedMinutes = pxToSnappedMinutes(ds.currentTopPx)
+    const newTime = minutesToTimeStr(snappedMinutes)
+    const datePart = task.scheduled_date!.slice(0, 10)
+    const deltaMinutes = snappedMinutes - ds.startTopPx // startTopPx is in px == minutes
+
+    const patches: Promise<Response>[] = [
+      fetch(`${API_URL}/tasks/${task.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scheduled_date: `${datePart}T${newTime}` }),
+      }),
+    ]
+
+    // Patch other selected timed tasks by the same delta
+    for (const [id, origTop] of ds.groupOrigTops) {
+      const t = tasks.find(t => t.id === id)
+      if (!t?.scheduled_date?.includes('T')) continue
+      const newMinutes = pxToSnappedMinutes(origTop + deltaMinutes)
+      const tDatePart = t.scheduled_date.slice(0, 10)
+      patches.push(
+        fetch(`${API_URL}/tasks/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ scheduled_date: `${tDatePart}T${minutesToTimeStr(newMinutes)}` }),
+        })
+      )
+    }
+
+    try {
+      await Promise.all(patches)
+      onTasksUpdate()
+    } catch {
+      // Ignore errors
+    }
+  }
+
+  function handleDragCancel() {
+    const ds = dragStateRef.current
+    if (!ds) return
+    ds.element.style.top = `${ds.startTopPx}px`
+    for (const [id, origTop] of ds.groupOrigTops) {
+      const otherEl = taskBlockRefsMap.current.get(id)
+      if (otherEl) otherEl.style.top = `${origTop}px`
+    }
+    dragStateRef.current = null
+    setDraggingTaskId(null)
+  }
+
+  function openReschedulePopup(e: React.MouseEvent) {
+    setRescheduleDate(selectedDate)
+    setReschedulePopup({ x: e.clientX, y: e.clientY })
+  }
+
+  async function applyReschedule() {
+    if (!rescheduleDate) return
+    try {
+      await Promise.all(
+        Array.from(selectedIds).map(id => {
+          const t = tasks.find(t => t.id === id)
+          // Preserve existing time if the task has one; otherwise use date-only
+          const existingTime = t?.scheduled_date?.includes('T')
+            ? t.scheduled_date.slice(11, 16)
+            : null
+          const newScheduledDate = existingTime
+            ? `${rescheduleDate}T${existingTime}`
+            : rescheduleDate
+          return fetch(`${API_URL}/tasks/${id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ scheduled_date: newScheduledDate }),
+          })
+        })
+      )
+      onTasksUpdate()
+    } catch {
+      // Ignore errors
+    }
+    setReschedulePopup(null)
   }
 
   function formatDateTime(dateStr: string | null): string {
@@ -416,11 +594,13 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
               const duration = task.duration_minutes || DEFAULT_DURATION
               const heightPx = duration * (HOUR_HEIGHT / 60)
 
+              const isDraggingThis = draggingTaskId === task.id
               const classes = [
                 'calendar-task-block',
                 task.completed ? 'completed' : '',
                 task.is_template ? 'projected' : '',
-                isSelected ? 'selected' : ''
+                isSelected ? 'selected' : '',
+                isDraggingThis ? 'dragging' : '',
               ].filter(Boolean).join(' ')
 
               const { colIndex, colCount } = layouts[i]
@@ -436,9 +616,21 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
                 <div
                   key={task.id + (task.is_template ? '-template' : '')}
                   className={classes}
+                  data-task-id={task.id}
+                  ref={(el) => {
+                    if (el) taskBlockRefsMap.current.set(task.id, el)
+                    else taskBlockRefsMap.current.delete(task.id)
+                  }}
                   style={{ top: topPx, height: Math.max(heightPx, 16), ...overlapStyle }}
                   onMouseDown={(e) => e.shiftKey && e.preventDefault()}
-                  onClick={(e) => handleSelectBoxClick(task, indexInOrdered, e)}
+                  onClick={(e) => {
+                    if (dragJustFinishedRef.current) { dragJustFinishedRef.current = false; return }
+                    handleSelectBoxClick(task, indexInOrdered, e)
+                  }}
+                  onPointerDown={(e) => handleDragStart(e, task, topPx)}
+                  onPointerMove={handleDragMove}
+                  onPointerUp={(e) => handleDragEnd(e, task)}
+                  onPointerCancel={handleDragCancel}
                 >
                   <input
                     type="checkbox"
@@ -512,9 +704,14 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
             >Calendar</button>
           </div>
           {selectedIds.size > 0 && (
-            <button type="button" className="delete-selected-btn" onClick={handleDeleteSelected}>
-              <TrashIcon /> Delete
-            </button>
+            <div className="day-view-actions">
+              <button type="button" className="reschedule-selected-btn" onClick={openReschedulePopup}>
+                Reschedule
+              </button>
+              <button type="button" className="delete-selected-btn" onClick={handleDeleteSelected}>
+                <TrashIcon /> Delete
+              </button>
+            </div>
           )}
         </div>
         {dayViewMode === 'list' ? (
@@ -690,6 +887,34 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
           <div className="confirm-actions">
             <button type="button" className="confirm-cancel-btn" onClick={() => setConfirmDelete(null)}>Cancel</button>
             <button type="button" className="confirm-delete-btn" onClick={() => confirmDeleteAction(confirmDelete.ids)}>Delete</button>
+          </div>
+        </div>
+      )}
+
+      {reschedulePopup && (
+        <div
+          className="confirm-popup reschedule-popup"
+          style={{
+            left: reschedulePopup.x,
+            top: Math.max(8, Math.min(reschedulePopup.y, window.innerHeight - 160)),
+            transform: 'translateX(-100%)',
+          }}
+        >
+          <p className="confirm-message">Reschedule {selectedIds.size} task{selectedIds.size !== 1 ? 's' : ''}</p>
+          <div className="reschedule-fields">
+            <label className="reschedule-label">
+              Date
+              <input
+                type="date"
+                className="reschedule-input"
+                value={rescheduleDate}
+                onChange={e => setRescheduleDate(e.target.value)}
+              />
+            </label>
+          </div>
+          <div className="confirm-actions">
+            <button type="button" className="confirm-cancel-btn" onClick={() => setReschedulePopup(null)}>Cancel</button>
+            <button type="button" className="confirm-delete-btn" onClick={applyReschedule} disabled={!rescheduleDate}>Apply</button>
           </div>
         </div>
       )}

--- a/frontend/src/utils/calendarLayout.test.ts
+++ b/frontend/src/utils/calendarLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeColumnLayout, DEFAULT_DURATION } from './calendarLayout'
+import { computeColumnLayout, DEFAULT_DURATION, pxToSnappedMinutes, minutesToTimeStr } from './calendarLayout'
 
 // Minimal task stub. Assumption: scheduled_date is YYYY-MM-DDTHH:MM.
 function task(time: string, duration: number | null = 30) {
@@ -68,4 +68,32 @@ describe('computeColumnLayout', () => {
     expect(result[1].colCount).toBe(2)
     expect(result[0].colIndex).not.toBe(result[1].colIndex)
   })
+})
+
+describe('pxToSnappedMinutes', () => {
+  it('snaps to nearest 15-minute mark', () => {
+    expect(pxToSnappedMinutes(0)).toBe(0)      // 00:00
+    expect(pxToSnappedMinutes(60)).toBe(60)    // 01:00 exactly
+    expect(pxToSnappedMinutes(547)).toBe(540)  // 9:07 raw → 9:00 (540 is closer than 555)
+    expect(pxToSnappedMinutes(553)).toBe(555)  // 9:13 raw → 9:15
+    expect(pxToSnappedMinutes(540)).toBe(540)  // 9:00 exactly
+    expect(pxToSnappedMinutes(555)).toBe(555)  // 9:15 exactly
+  })
+
+  it('clamps below 0 to 0', () => {
+    expect(pxToSnappedMinutes(-100)).toBe(0)
+  })
+
+  it('clamps above max to 1439', () => {
+    // snap(1500)=1500, clamp→1439; snap(1440)=1440, clamp→1439
+    expect(pxToSnappedMinutes(1500)).toBe(1439)
+    expect(pxToSnappedMinutes(1440)).toBe(1439)
+  })
+})
+
+describe('minutesToTimeStr', () => {
+  it('formats midnight', () => expect(minutesToTimeStr(0)).toBe('00:00'))
+  it('formats noon', () => expect(minutesToTimeStr(720)).toBe('12:00'))
+  it('formats 9:05', () => expect(minutesToTimeStr(545)).toBe('09:05'))
+  it('formats 23:59', () => expect(minutesToTimeStr(1439)).toBe('23:59'))
 })

--- a/frontend/src/utils/calendarLayout.ts
+++ b/frontend/src/utils/calendarLayout.ts
@@ -1,5 +1,28 @@
 // Fallback duration when duration_minutes is null. Assumption: matches TaskList.tsx DEFAULT_DURATION.
 export const DEFAULT_DURATION = 30 // minutes
+export const HOUR_HEIGHT_PX = 60 // px per hour; 1px per minute — must match TaskList.tsx HOUR_HEIGHT
+export const SNAP_MINUTES = 15 // drag snap increment
+
+/**
+ * Convert a pixel offset from the top of the calendar grid to a snapped minute-of-day.
+ * Clamps to [0, 1439].
+ * Assumption: HOUR_HEIGHT_PX = 60 (1px per minute).
+ */
+export function pxToSnappedMinutes(px: number): number {
+  const raw = Math.round(px) // 1px == 1 minute
+  const snapped = Math.round(raw / SNAP_MINUTES) * SNAP_MINUTES
+  return Math.max(0, Math.min(1439, snapped))
+}
+
+/**
+ * Format a minute-of-day as HH:MM.
+ * Assumption: minutes is in [0, 1439].
+ */
+export function minutesToTimeStr(minutes: number): string {
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
 
 // Minimal task shape required by computeColumnLayout
 interface ScheduledTask {


### PR DESCRIPTION
Changelog:
---

- Implemented drag-and-drop support for task reordering in the calendar view, allowing users to move tasks by dragging.
- Added a rescheduling popup for bulk rescheduling of selected tasks, improving user experience for managing task dates.
- Introduced utility functions for snapping pixel values to the nearest 15-minute increment and formatting time strings.
- Updated CSS styles for task blocks and rescheduling elements to improve visual feedback during drag operations.

Closes #48 

Screenshots:
<img width="962" height="996" alt="image" src="https://github.com/user-attachments/assets/fe049f72-00bb-4bde-9fbf-ccdc0de08d5a" />
<img width="964" height="925" alt="image" src="https://github.com/user-attachments/assets/eb63d71f-8b6a-4610-b461-28f64ae6543c" />

