### PR TITLE
Issue 69 & 70 - Fix selection state: clear on tab change / bulk ops, gate bulk delete to 2+

### DIFF
--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -136,6 +136,12 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
   const [reschedulePopup, setReschedulePopup] = useState<{ x: number; y: number } | null>(null)
   const [rescheduleDate, setRescheduleDate] = useState<string>('')
 
+  // Clear selection when switching main tabs
+  useEffect(() => {
+    setSelectedIds(new Set())
+    lastClickedIndexRef.current = null
+  }, [viewMode])
+
   // Auto-scroll calendar to ~8am when switching to calendar view
   useEffect(() => {
     if (dayViewMode === 'calendar' && calendarRef.current) {
@@ -145,11 +151,9 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
 
   async function handleToggle(task: Task) {
     const newCompleted = !task.completed
+    const isBulk = selectedIds.has(task.id) && selectedIds.size > 1
+    const ids = isBulk ? Array.from(selectedIds) : [task.id]
     try {
-      // If task is part of a multi-selection, apply to all selected
-      const ids = selectedIds.has(task.id) && selectedIds.size > 1
-        ? Array.from(selectedIds)
-        : [task.id]
       await Promise.all(ids.map(id =>
         fetch(`${API_URL}/tasks/${id}`, {
           method: 'PATCH',
@@ -158,6 +162,7 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
         })
       ))
       onTasksUpdate()
+      if (isBulk) setSelectedIds(new Set())
     } catch (err) {
       // Ignore errors
     }
@@ -385,6 +390,7 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
         })
       )
       onTasksUpdate()
+      setSelectedIds(new Set())
     } catch {
       // Ignore errors
     }
@@ -708,9 +714,11 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
               <button type="button" className="reschedule-selected-btn" onClick={openReschedulePopup}>
                 Reschedule
               </button>
-              <button type="button" className="delete-selected-btn" onClick={handleDeleteSelected}>
-                <TrashIcon /> Delete
-              </button>
+              {selectedIds.size > 1 && (
+                <button type="button" className="delete-selected-btn" onClick={handleDeleteSelected}>
+                  <TrashIcon /> Delete
+                </button>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

Fixes two related selection-state bugs in `TaskList.tsx`:

- **#69 Clear selection after non-delete ops / tab change**: `selectedIds` was persisting when it should not. Added a `useEffect` on `viewMode` to clear selection on every main-tab switch (Day → All → Completed → Backlog). Also clears selection after a successful bulk reschedule and after a successful bulk toggle-complete.

- **#70 Bulk delete only when 2+ selected**: The bulk Delete button was shown even for a single selected task. It is now gated to `selectedIds.size > 1`; single-task deletion continues to work via the per-row trash icon. Reschedule remains available for 1+ selected tasks.

Date navigation within Day view intentionally does not clear selection (the issue specifies "at minimum tab changes").

## Linked Issue

Closes #69
Closes #70

## Test Plan

- [x] Select one task in Day view → Reschedule button appears, Delete button does **not** appear.
- [x] Select two or more tasks in Day view → both Reschedule and Delete buttons appear.
- [x] Reschedule selected tasks → confirm selection clears after apply.
- [x] Bulk-toggle complete on multiple selected tasks → confirm selection clears after toggle.
- [x] With tasks selected, switch from Day to All Tasks (and to Completed / Backlog) → selection clears each time.
- [x] Switch back to Day view → no stale selection carried over.
- [x] Single-task delete via per-row trash still works as before.

## Checklist

- [x] All existing tests pass
- [x] New tests added for new behavior (if applicable)
- [x] Docs updated (if applicable)
- [x] No unrelated changes included


