### PR TITLE
fix: surface overdue tasks via dedicated query (#67)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,7 @@ Issue <N> - <short description> (#<PR>)
 ```
 
 Example: `Issue 46 - Add CONTRIBUTING.md (#47)`
+
+## Merging
+
+All PRs are merged by project maintainers after review.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,43 @@
+# Hakadorio
+
+A personal task management app with an AI-powered chat interface for creating, scheduling, and organizing tasks. Single-user, local-first.
+
+## Stack
+
+- **Frontend**: React 18 + TypeScript + Vite, pnpm. Source in [frontend/src/](frontend/src/).
+- **Backend**: FastAPI + SQLModel (SQLAlchemy ORM) + Alembic + SQLite. Source in [backend/](backend/).
+- **LLM**: Anthropic Claude via the `anthropic` SDK, orchestrated with LangGraph.
+
+## Architecture
+
+```
+frontend/src/        React UI: TaskList, ChatInterface, calendar/list day view
+backend/main.py      FastAPI routes (/tasks, /chat, /conversations, /settings)
+backend/graph.py     LangGraph chat flow: classify_intent → fetch_tasks → execute_*
+backend/database.py  ORM CRUD; alembic migrations under backend/alembic/versions/
+backend/models.py    SQLModel tables (Task, CategorySequence, Conversation) + API schemas
+backend/prompts.py   System prompts for intent classification, operations, reschedule
+backend/scheduling.py  Schedule context builder (gaps, conflicts) for auto-scheduling
+```
+
+## Data Model
+
+- **Task** — `id`, `task_key` (e.g. `T-05`, `M-01`), `category`, `task_number`, `title`, `completed`, `scheduled_date` (`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM`), `recurrence_rule`, `is_template`, `parent_task_id`, `duration_minutes`, `priority` (0–4).
+- **CategorySequence** — per-category counter for `task_number`.
+- **Conversation** — chat history (JSON-encoded `messages`, `title`).
+
+Categories: `T` (regular), `D` (daily), `M` (meeting), or any user-defined custom category. Recurring tasks are stored as templates (`is_template=True`); instances are generated per date via `get_tasks_for_date()`.
+
+## Key Workflows
+
+**Chat → operation**: `POST /chat` → `chat_graph.ainvoke()` → `classify_intent` (task_operation | clarification_answer | reschedule) → `fetch_tasks_*` → `execute_operation` or `execute_reschedule` → returns `final_response` + updated task list.
+
+**Auto-scheduling**: When a task is created for today without a time, `build_schedule_context()` injects today's schedule + available gaps into the LLM prompt; the LLM picks a slot.
+
+**Conflict resolution**: User setting `conflict_resolution` controls behavior when a new task overlaps an existing one — `overlap`, `unschedule`, or `backlog`.
+
+## Conventions
+
+- Branches, commits, migrations, tests: see [CONTRIBUTING.md](CONTRIBUTING.md).
+- Claude communication style and behavior rules: see [CLAUDE.md](CLAUDE.md).
+- Tests: unit tests in [backend/tests/unit/](backend/tests/unit/), LLM integration tests in [backend/tests/llm/](backend/tests/llm/) (run with `pytest --run-llm`).

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,31 @@
+# Backend (FastAPI + SQLModel + SQLite)
+
+## What's here
+
+- `main.py` — FastAPI app, all HTTP routes (one file, no routers/blueprints), startup runs Alembic via `init_db()`.
+- `database.py` — SQLModel data layer: task CRUD, task numbering, recurrence calculation, `get_tasks_for_date()`, `get_overdue_tasks()`, settings, conversations.
+- `models.py` — SQLModel table classes (`Task`, `CategorySequence`, `Conversation`, `UserSettings`) and non-table API schemas (`TaskUpdate`, `UserSettingsRead`, `UserSettingsUpdate`, `ChatRequest`, `Message`).
+- `graph.py` — LangGraph pipeline for the `/chat` endpoint (intent classification → operation execution).
+- `prompts.py` — System prompts.
+- `scheduling.py` — Schedule context builder for prompts.
+- `alembic/` — Migrations.
+
+## Design notes
+
+- **Sync-first.** All routes are sync `def` except `/chat` and the title-generation helper, which are `async` only because they await Anthropic SDK calls.
+- **No background-task infrastructure.** No `BackgroundTasks`, threading, scheduler, or queue. Add one only if a task genuinely cannot run within the request lifecycle.
+- **Per-operation sessions.** Every DB op opens its own `Session(engine)` block and commits before returning. Returned ORM objects are detached via `.model_copy()` so callers can use them after the session closes.
+- **`get_all_tasks()` then filter in Python** is the prevailing pattern for query-shaped functions (`get_tasks_for_date`, `get_overdue_tasks`). Volumes are small; SQL-side filtering isn't worth the complexity yet.
+- **Today is server-local.** `datetime.now().strftime("%Y-%m-%d")` — no client TZ, no UTC.
+- **Templates vs instances.** Recurring tasks are stored as templates (`is_template=True`, key prefix `R-`). Instances are materialized on demand by `get_tasks_for_date()` for today, or rendered as projections (template returned with overridden `scheduled_date`) for past/future dates.
+- **`scheduled_date` format.** `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM`. Lexicographic comparison works for date-prefix ordering. Use `scheduled_date[:10]` to extract the date portion.
+- **Categories.** `M` = meeting (time-bound, never carried/overdue), `D` = daily, `T` = generic task, others = projects.
+
+## Guidelines for changes
+
+- Add new endpoints in `main.py` next to related existing ones; don't introduce routers unless the file becomes unmanageable.
+- New DB ops go in `database.py`. Match the existing style: open a `Session`, do work, commit, return detached copies.
+- Schema changes need an Alembic migration. Never drop columns without a migration.
+- Don't add blocking I/O to a sync route; if you need to, switch the route to `async def` and use the async client (`anthropic.AsyncAnthropic` is already wired up).
+- Lexicographic date math is fine for the current `scheduled_date` format. Don't add `dateutil` for trivial cases.
+- When filtering tasks, remember to handle: templates (`is_template`), recurrent instances (`parent_task_id` set), meetings (`category == "M"`), and completed (`completed`) — most filters need at least three of these.

--- a/backend/database.py
+++ b/backend/database.py
@@ -313,17 +313,29 @@ def get_tasks_for_date(target_date: str, today: str) -> list[Task]:
                         result.append(projection)
             continue
 
-        # Non-template tasks
+        # Non-template tasks: strict equality on scheduled date.
+        # Overdue tasks are surfaced via get_overdue_tasks(), not carried forward here.
         if scheduled_date_only == target_date:
             result.append(task)
-            continue
 
-        # For today only: include incomplete non-recurrent tasks with past scheduled_date (overdue)
-        # Excluded: recurrent instances (each day gets its own) and meetings (time-bound events)
-        if is_today and scheduled_date_only and scheduled_date_only < today and not task.completed and not task.parent_task_id and task.category != "M":
+    return result
+
+
+def get_overdue_tasks(today: str) -> list[Task]:
+    """
+    Return incomplete, non-recurrent, non-meeting tasks whose scheduled_date is before today.
+    Excludes templates, recurrent instances (parent_task_id set), meetings (M), and completed tasks.
+    today: YYYY-MM-DD. Compared lexicographically against scheduled_date[:10].
+    """
+    all_tasks = get_all_tasks()
+    result: list[Task] = []
+    for task in all_tasks:
+        if task.is_template or task.completed or task.parent_task_id or task.category == "M":
+            continue
+        if not task.scheduled_date:
+            continue
+        if task.scheduled_date[:10] < today:
             result.append(task)
-            continue
-
     return result
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from database import (
     init_db,
     get_all_tasks,
     get_tasks_for_date,
+    get_overdue_tasks,
     create_task_db,
     update_task_db,
     delete_task_db,
@@ -67,6 +68,13 @@ def get_tasks_for_date_endpoint(date: str) -> list[Task]:
     """Get tasks for a specific date (day view)."""
     today = datetime.now().strftime("%Y-%m-%d")
     return get_tasks_for_date(date, today)
+
+
+@app.get("/tasks/overdue")
+def get_overdue_tasks_endpoint() -> list[Task]:
+    """Get tasks with scheduled_date before today (incomplete, non-recurrent, non-meeting)."""
+    today = datetime.now().strftime("%Y-%m-%d")
+    return get_overdue_tasks(today)
 
 
 @app.patch("/tasks/{task_id}")

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -1,0 +1,30 @@
+# Backend tests
+
+## Layout
+
+- `unit/` — deterministic tests (no external API). Run by default.
+- `llm/` — tests that call the Anthropic API. Skipped unless `pytest --run-llm`.
+- `conftest.py` — shared fixtures and the `--run-llm` flag.
+
+## Fixtures (conftest.py)
+
+- `test_db` — creates an isolated temp-file SQLite DB per test, monkeypatches `database.engine` and disables `init_db` (no Alembic). Yields the DB path.
+- `app_client` — wraps `main.app` in a FastAPI `TestClient`. Depends on `test_db`.
+
+A temp-file DB (not `:memory:`) is required because each `database.py` operation opens its own `Session`, so an in-memory DB would be reset between calls.
+
+## Running
+
+```
+.venv/Scripts/python.exe -m pytest tests/unit/ -q       # default
+.venv/Scripts/python.exe -m pytest --run-llm            # include LLM tests
+.venv/Scripts/python.exe -m pytest -m llm --run-llm     # LLM only
+```
+
+## Conventions
+
+- Group related tests in classes (`TestTaskCRUD`, `TestOverdueFiltering`, etc.).
+- Each test takes the `test_db` fixture even when not used directly — it ensures a clean DB.
+- Endpoint tests use the `app_client` fixture and assert on `response.status_code` + `response.json()`.
+- To pin "today" in endpoint tests, monkeypatch `main.datetime` with a `datetime` subclass that overrides `now()`. Pattern: see `TestOverdueEndpoint._pin_today` in `unit/test_api.py`.
+- Don't write LLM tests without an `llm` marker — they'll run by accident.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -74,7 +74,10 @@ def app_client(test_db, monkeypatch):
     from fastapi.testclient import TestClient
     import main
 
-    monkeypatch.setattr(database, "init_db", lambda: None)
+    # main.py did `from database import init_db`, so the FastAPI lifespan calls
+    # main.init_db (a local binding to the original function). Patching
+    # database.init_db has no effect — patch main.init_db directly.
+    monkeypatch.setattr(main, "init_db", lambda: None)
 
     with TestClient(main.app) as client:
         yield client

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -74,6 +74,47 @@ class TestTaskEndpoints:
         assert response.status_code == 404
 
 
+class TestOverdueEndpoint:
+    """Tests for GET /tasks/overdue. Pins 'today' via monkeypatching main.datetime."""
+
+    def _pin_today(self, monkeypatch, today_str: str):
+        """Replace main.datetime so datetime.now() returns a fixed date."""
+        import main
+        from datetime import datetime as real_datetime
+
+        class _FrozenDatetime(real_datetime):
+            @classmethod
+            def now(cls, tz=None):
+                y, m, d = map(int, today_str.split("-"))
+                return real_datetime(y, m, d)
+
+        monkeypatch.setattr(main, "datetime", _FrozenDatetime)
+
+    def test_returns_overdue_tasks(self, test_db, app_client, monkeypatch):
+        self._pin_today(monkeypatch, "2025-06-15")
+        create_task_db("old-1", "Old task", "T", "2025-06-01")
+        create_task_db("today-1", "Today task", "T", "2025-06-15")
+        create_task_db("future-1", "Future task", "T", "2025-06-20")
+
+        response = app_client.get("/tasks/overdue")
+
+        assert response.status_code == 200
+        ids = [t["id"] for t in response.json()]
+        assert ids == ["old-1"]
+
+    def test_excludes_meetings_and_recurrent_instances(self, test_db, app_client, monkeypatch):
+        self._pin_today(monkeypatch, "2025-06-15")
+        create_task_db("mtg-1", "Old meeting", "M", "2025-06-01T09:00")
+        create_task_db("tpl-1", "Stretch", "D", "2025-06-01", "daily", is_template=True)
+        create_task_db("inst-1", "Stretch", "D", "2025-06-01", "daily",
+                       is_template=False, parent_task_id="tpl-1")
+
+        response = app_client.get("/tasks/overdue")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+
 class TestConversationEndpoint:
     """Tests for /conversation endpoint."""
 

--- a/backend/tests/unit/test_database.py
+++ b/backend/tests/unit/test_database.py
@@ -14,6 +14,7 @@ from database import (
     delete_task_db,
     get_all_tasks,
     get_tasks_for_date,
+    get_overdue_tasks,
     find_task_by_title_db,
     find_task_by_key_db,
     get_next_task_number,
@@ -382,11 +383,11 @@ class TestTemplateStartDate:
         assert tasks[0].is_template is False
 
 
-class TestOverdueFiltering:
-    """Tests for overdue task filtering in day view."""
+class TestDayViewOverdueExclusion:
+    """Day view (get_tasks_for_date) excludes overdue tasks; they surface via get_overdue_tasks instead."""
 
     def test_overdue_recurrent_instance_excluded(self, test_db):
-        tpl = create_task_db("tpl-1", "Stretch", "D", "2025-06-01", "daily", is_template=True)
+        create_task_db("tpl-1", "Stretch", "D", "2025-06-01", "daily", is_template=True)
         create_task_db("inst-old", "Stretch", "D", "2025-06-01", "daily",
                        is_template=False, parent_task_id="tpl-1")
 
@@ -395,15 +396,16 @@ class TestOverdueFiltering:
 
         assert "inst-old" not in task_ids
 
-    def test_overdue_non_recurrent_task_included(self, test_db):
+    def test_overdue_non_recurrent_task_excluded(self, test_db):
+        """Overdue tasks no longer carry forward into today's day view."""
         create_task_db("task-1", "Buy groceries", "T", "2025-06-01")
 
         tasks = get_tasks_for_date("2025-06-15", "2025-06-15")
         task_ids = [t.id for t in tasks]
 
-        assert "task-1" in task_ids
+        assert "task-1" not in task_ids
 
-    def test_completed_non_recurrent_task_excluded(self, test_db):
+    def test_completed_overdue_task_excluded(self, test_db):
         create_task_db("task-1", "Buy groceries", "T", "2025-06-01")
         update_task_db("task-1", completed=True)
 
@@ -411,6 +413,77 @@ class TestOverdueFiltering:
         task_ids = [t.id for t in tasks]
 
         assert "task-1" not in task_ids
+
+
+class TestGetOverdueTasks:
+    """Tests for get_overdue_tasks: returns incomplete past-scheduled tasks excluding meetings/recurrent/templates."""
+
+    def test_returns_overdue_non_recurrent_task(self, test_db):
+        create_task_db("task-1", "Buy groceries", "T", "2025-06-01")
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert [t.id for t in result] == ["task-1"]
+
+    def test_excludes_today_scheduled_task(self, test_db):
+        create_task_db("task-1", "Today task", "T", "2025-06-15")
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert result == []
+
+    def test_excludes_future_scheduled_task(self, test_db):
+        create_task_db("task-1", "Future task", "T", "2025-06-20")
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert result == []
+
+    def test_excludes_completed_task(self, test_db):
+        create_task_db("task-1", "Done", "T", "2025-06-01")
+        update_task_db("task-1", completed=True)
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert result == []
+
+    def test_excludes_recurrent_instance(self, test_db):
+        create_task_db("tpl-1", "Stretch", "D", "2025-06-01", "daily", is_template=True)
+        create_task_db("inst-old", "Stretch", "D", "2025-06-01", "daily",
+                       is_template=False, parent_task_id="tpl-1")
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert [t.id for t in result] == []
+
+    def test_excludes_meetings(self, test_db):
+        create_task_db("mtg-1", "Standup", "M", "2025-06-01T09:00")
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert result == []
+
+    def test_excludes_template(self, test_db):
+        create_task_db("tpl-1", "Daily standup", "D", "2025-06-01", "daily", is_template=True)
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert result == []
+
+    def test_excludes_unscheduled_backlog_task(self, test_db):
+        create_task_db("task-1", "Someday", "T", None)
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert result == []
+
+    def test_handles_datetime_scheduled_date(self, test_db):
+        """scheduled_date with time portion (YYYY-MM-DDTHH:MM) compares on date prefix only."""
+        create_task_db("task-1", "Old timed task", "T", "2025-06-01T15:30")
+
+        result = get_overdue_tasks("2025-06-15")
+
+        assert [t.id for t in result] == ["task-1"]
 
 
 class TestConversation:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ function formatDateStr(date: Date): string {
 
 function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [overdueTasks, setOverdueTasks] = useState<Task[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>('day');
   const [showSettings, setShowSettings] = useState(false);
   const [quickEntryOpen, setQuickEntryOpen] = useState(false);
@@ -77,9 +78,20 @@ function App() {
         viewMode === "day"
           ? `${API_URL}/tasks/for-date?date=${selectedDate}`
           : `${API_URL}/tasks`;
-      const res = await fetch(url);
+      // Overdue is a separate query, only relevant when viewing today's day view.
+      const showOverdue = viewMode === "day" && selectedDate === todayStr;
+      const [res, overdueRes] = await Promise.all([
+        fetch(url),
+        showOverdue ? fetch(`${API_URL}/tasks/overdue`) : Promise.resolve(null),
+      ]);
       const data = await res.json();
       setTasks(data);
+      if (overdueRes) {
+        const overdueData = await overdueRes.json();
+        setOverdueTasks(overdueData);
+      } else {
+        setOverdueTasks([]);
+      }
     } catch (err) {
       console.error("Failed to fetch tasks:", err);
     }
@@ -110,6 +122,7 @@ function App() {
       <main className="main">
         <TaskList
           tasks={tasks}
+          overdueTasks={overdueTasks}
           viewMode={viewMode}
           selectedDate={selectedDate}
           todayStr={todayStr}

--- a/frontend/src/CLAUDE.md
+++ b/frontend/src/CLAUDE.md
@@ -1,0 +1,33 @@
+# Frontend (React + Vite + TypeScript)
+
+## Layout
+
+- `App.tsx` — root component. Owns task fetching (`tasks`, `overdueTasks`), view mode, selected date, modal toggles. Passes data + callbacks down.
+- `main.tsx` — Vite entry point.
+- `components/`
+  - `TaskList.tsx` — day/all/completed/backlog views, list+calendar modes, drag/drop, multi-select, bulk delete/reschedule.
+  - `ChatInterface.tsx` — chat panel, conversation history.
+  - `SettingsModal.tsx` — user settings form.
+  - `QuickEntry.tsx` — Ctrl+. spotlight-style task creation.
+- `utils/calendarLayout.ts` — column packing for overlapping calendar blocks, snap-to-minutes helpers.
+- `App.css` / `index.css` — styles. Theme via CSS custom properties.
+
+## Design notes
+
+- **API base** is hard-coded `http://localhost:8000` in each component that needs it. There is no shared client wrapper; calls use native `fetch()`.
+- **Task shape duplicated.** `App.tsx` and `TaskList.tsx` each declare their own `Task` interface. They must stay in sync with each other and with `backend/models.py`. Comment them with the `// Assumption:` prefix when adding fields.
+- **Single source of truth for tasks** is `App.tsx`'s `tasks` state, refilled by `fetchTasks()`. Children call `onTasksUpdate()` after mutations to trigger a refetch.
+- **Today is client-local.** `formatDateStr(new Date())` builds `YYYY-MM-DD` from local components. No timezone is sent to the backend; backend uses server-local. This works because dev is single-user on one machine.
+- **Day view** uses `GET /tasks/for-date?date=...`. When the selected date equals today, App also fetches `GET /tasks/overdue` in parallel and passes the result as `overdueTasks` to TaskList. TaskList renders Overdue as the first section above Meetings/Daily/Tasks (list mode only).
+- **Selection state** lives in TaskList. `orderedVisibleTasksRef` tracks the currently rendered order so shift-click range selection works across sections.
+- **Drag/drop** is calendar-mode-only and timed-tasks-only. Group drag uses `selectedIds` to move other selected timed tasks by the same delta. Lookup uses `tasks.find` — overdue tasks aren't in `tasks`, so they can't be dragged (intentional; they aren't on today's calendar).
+
+## Guidelines for changes
+
+- Prefer co-locating a new view's data fetch in `App.tsx` and passing as a prop, over fetching inside a component. Children should be presentational where possible.
+- After a write, call `onTasksUpdate()` rather than mutating local state — the refetch keeps everything consistent.
+- Bulk operations on selections may include ids from sources outside `tasks` (e.g. `overdueTasks`). When looking up by id, fall back: `tasks.find(...) ?? overdueTasks.find(...)`.
+- Section ordering and `orderedVisibleTasksRef` must stay aligned. When you add a section, increment a running index and pass it as `startIndex` to `renderSection`.
+- Don't add a styling library or component framework — this is a deliberately small CSS-driven UI.
+- Type the Task interface explicitly in any new component that holds tasks. Don't import types across components — duplicate them with the `// Assumption:` comment.
+- Don't introduce a global API client unless we have a reason; the duplicated `fetch` calls are intentional for now.

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -23,6 +23,8 @@ type DayViewMode = 'list' | 'calendar'
 
 interface TaskListProps {
   tasks: Task[]
+  // Overdue tasks shown above today's day view. Empty when not viewing today.
+  overdueTasks?: Task[]
   viewMode: ViewMode
   selectedDate: string
   todayStr: string
@@ -108,7 +110,7 @@ const SCROLL_TO_HOUR = 8 // auto-scroll to 8am on mount
 const LABEL_WIDTH = 55 // px
 const RIGHT_PAD = 8   // px
 
-function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, onDateChange, onTasksUpdate }: TaskListProps) {
+function TaskList({ tasks, overdueTasks = [], viewMode, selectedDate, todayStr, onViewModeChange, onDateChange, onTasksUpdate }: TaskListProps) {
   const [dayViewMode, setDayViewMode] = useState<DayViewMode>('list')
   const calendarRef = useRef<HTMLDivElement>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
@@ -299,7 +301,7 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
     }
   }
 
-  async function handleDragEnd(e: React.PointerEvent, task: Task) {
+  async function handleDragEnd(_e: React.PointerEvent, task: Task) {
     const ds = dragStateRef.current
     if (!ds || ds.taskId !== task.id) return
 
@@ -370,7 +372,8 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
     try {
       await Promise.all(
         Array.from(selectedIds).map(id => {
-          const t = tasks.find(t => t.id === id)
+          // Selection may include overdue tasks (rendered above today's day view) which are not in `tasks`.
+          const t = tasks.find(t => t.id === id) ?? overdueTasks.find(t => t.id === id)
           // Preserve existing time if the task has one; otherwise use date-only
           const existingTime = t?.scheduled_date?.includes('T')
             ? t.scheduled_date.slice(11, 16)
@@ -718,18 +721,29 @@ function TaskList({ tasks, viewMode, selectedDate, todayStr, onViewModeChange, o
           )}
         </div>
         {dayViewMode === 'list' ? (
-          isEmpty ? (
+          isEmpty && overdueTasks.length === 0 ? (
             <p className="empty-state">No tasks for this day.</p>
           ) : (
             <>
               {(() => {
-                const ordered = [...meetings, ...daily, ...other]
+                // Overdue first (only populated when viewing today, per App.tsx).
+                // showDate=true on overdue rows so users see the original scheduled date.
+                const ordered = [...overdueTasks, ...meetings, ...daily, ...other]
                 orderedVisibleTasksRef.current = ordered
+                let idx = 0
+                const overdueSection = renderSection('Overdue', overdueTasks, true, idx)
+                idx += overdueTasks.length
+                const meetingsSection = renderSection('Meetings', meetings, false, idx)
+                idx += meetings.length
+                const dailySection = renderSection('Daily', daily, false, idx)
+                idx += daily.length
+                const otherSection = renderSection('Tasks', other, false, idx)
                 return (
                   <>
-                    {renderSection('Meetings', meetings, false, 0)}
-                    {renderSection('Daily', daily, false, meetings.length)}
-                    {renderSection('Tasks', other, false, meetings.length + daily.length)}
+                    {overdueSection}
+                    {meetingsSection}
+                    {dailySection}
+                    {otherSection}
                   </>
                 )
               })()}


### PR DESCRIPTION
Closes #67.

## Summary
- Removed the carry-forward branch in `get_tasks_for_date()` — day view now returns only tasks whose `scheduled_date` matches the queried date.
- Added `GET /tasks/overdue` returning incomplete, non-recurrent, non-meeting tasks with `scheduled_date < today`.
- Frontend renders overdue tasks as a separate "Overdue" section above today's day view (list mode), with the original date shown.
- Bonus: fixed a pre-existing test fixture bug — `app_client` was patching `database.init_db`, but `main.py` does `from database import init_db`, so the lifespan called the unpatched original. Patching `main.init_db` directly resolves intermittent `FileNotFoundError` on alembic during full-suite runs.

See the design rationale on the issue: https://github.com/therogue/hakadorio-community/issues/67#issuecomment-4320217293

## Test plan
- [x] `pytest tests/unit/` — 241 passed (was 191 passed + 39 errors due to the alembic fixture bug)
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Manually verify in browser: overdue section appears above today's day view; toggling complete on an overdue task removes it; switching to a non-today date hides the overdue section
- [ ] Manually verify: bulk-reschedule selection that includes overdue tasks works (overdue task gets the new date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)