### PR TITLE
Issue 66: Bulk Move Day View Tasks to Backlog by Task ID

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ import json
 import anthropic
 from dotenv import load_dotenv
 
-from models import Task, TaskUpdate, ChatRequest, UserSettingsRead, UserSettingsUpdate
+from models import Task, TaskUpdate, BulkMoveToBacklogRequest, ChatRequest, UserSettingsRead, UserSettingsUpdate
 from prompts import TITLE_PROMPT
 from graph import GraphState, chat_graph
 from database import (
@@ -75,6 +75,17 @@ def get_overdue_tasks_endpoint() -> list[Task]:
     """Get tasks with scheduled_date before today (incomplete, non-recurrent, non-meeting)."""
     today = datetime.now().strftime("%Y-%m-%d")
     return get_overdue_tasks(today)
+
+    
+@app.post("/tasks/bulk-move-to-backlog")
+def bulk_move_to_backlog(body: BulkMoveToBacklogRequest) -> list[Task]:
+    updated = []
+    for task_id in body.task_ids:
+        result = update_task_db(task_id, scheduled_date=None)
+        if not result:
+            raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
+        updated.append(result)
+    return updated
 
 
 @app.patch("/tasks/{task_id}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ import json
 import anthropic
 from dotenv import load_dotenv
 
-from models import Task, TaskUpdate, BulkMoveToBacklogRequest, ChatRequest, UserSettingsRead, UserSettingsUpdate
+from models import Task, TaskUpdate, ChatRequest, UserSettingsRead, UserSettingsUpdate
 from prompts import TITLE_PROMPT
 from graph import GraphState, chat_graph
 from database import (
@@ -75,17 +75,6 @@ def get_overdue_tasks_endpoint() -> list[Task]:
     """Get tasks with scheduled_date before today (incomplete, non-recurrent, non-meeting)."""
     today = datetime.now().strftime("%Y-%m-%d")
     return get_overdue_tasks(today)
-
-    
-@app.post("/tasks/bulk-move-to-backlog")
-def bulk_move_to_backlog(body: BulkMoveToBacklogRequest) -> list[Task]:
-    updated = []
-    for task_id in body.task_ids:
-        result = update_task_db(task_id, scheduled_date=None)
-        if not result:
-            raise HTTPException(status_code=404, detail=f"Task not found: {task_id}")
-        updated.append(result)
-    return updated
 
 
 @app.patch("/tasks/{task_id}")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,6 @@
-from typing import Optional
+from typing import Annotated, Optional
 from sqlmodel import SQLModel, Field
+from pydantic import field_validator
 
 
 # --- Table models (ORM + Pydantic) ---
@@ -64,6 +65,17 @@ class UserSettingsUpdate(SQLModel):
     default_category: Optional[str] = None
     default_priority: Optional[str] = None
     conflict_resolution: Optional[str] = None
+
+
+class BulkMoveToBacklogRequest(SQLModel):
+    task_ids: list[str]
+
+    @field_validator("task_ids")
+    @classmethod
+    def task_ids_non_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("task_ids must not be empty")
+        return v
 
 
 class Message(SQLModel):

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,5 @@
-from typing import Annotated, Optional
+from typing import Optional
 from sqlmodel import SQLModel, Field
-from pydantic import field_validator
 
 
 # --- Table models (ORM + Pydantic) ---
@@ -66,16 +65,6 @@ class UserSettingsUpdate(SQLModel):
     default_priority: Optional[str] = None
     conflict_resolution: Optional[str] = None
 
-
-class BulkMoveToBacklogRequest(SQLModel):
-    task_ids: list[str]
-
-    @field_validator("task_ids")
-    @classmethod
-    def task_ids_non_empty(cls, v: list[str]) -> list[str]:
-        if not v:
-            raise ValueError("task_ids must not be empty")
-        return v
 
 
 class Message(SQLModel):

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -224,3 +224,60 @@ class TestSettingsEndpoints:
         response = app_client.get("/settings")
         assert response.status_code == 200
         assert response.json()["default_priority"] == "none"
+
+
+class TestBulkMoveToBacklog:
+    """Tests for POST /tasks/bulk-move-to-backlog (Issue #66)."""
+
+    def test_bulk_move_clears_scheduled_date(self, test_db, app_client):
+        """POST with valid IDs sets scheduled_date=None on all specified tasks."""
+        create_task_db("id-1", "Task 1", "T", "2026-05-02")
+        create_task_db("id-2", "Task 2", "T", "2026-05-02")
+        create_task_db("id-3", "Task 3", "T", "2026-05-02")
+
+        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1", "id-2"]})
+
+        assert response.status_code == 200
+        updated = {t["id"]: t for t in response.json()}
+        assert updated["id-1"]["scheduled_date"] is None
+        assert updated["id-2"]["scheduled_date"] is None
+
+    def test_bulk_move_does_not_affect_other_tasks(self, test_db, app_client):
+        """Tasks not in the request are not modified."""
+        create_task_db("id-1", "Task 1", "T", "2026-05-02")
+        create_task_db("id-2", "Task 2", "T", "2026-05-02")
+
+        app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1"]})
+
+        all_tasks = {t["id"]: t for t in app_client.get("/tasks").json()}
+        assert all_tasks["id-2"]["scheduled_date"] == "2026-05-02"
+
+    def test_bulk_move_empty_ids_returns_422(self, app_client):
+        """POST with empty task_ids list returns 422 validation error."""
+        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": []})
+        assert response.status_code == 422
+
+    def test_bulk_move_unknown_id_returns_404(self, app_client):
+        """POST with a non-existent task ID returns 404."""
+        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["ghost-id"]})
+        assert response.status_code == 404
+
+    def test_bulk_move_partial_failure_updates_preceding_tasks(self, test_db, app_client):
+        """Valid IDs before an unknown ID are updated; the request returns 404."""
+        create_task_db("id-1", "Task 1", "T", "2026-05-02")
+
+        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1", "ghost-id"]})
+
+        assert response.status_code == 404
+        # id-1 was updated before the 404 — partial write is the current behaviour
+        all_tasks = {t["id"]: t for t in app_client.get("/tasks").json()}
+        assert all_tasks["id-1"]["scheduled_date"] is None
+
+    def test_bulk_move_already_backlogged_task_is_idempotent(self, test_db, app_client):
+        """Moving a task already in the backlog (scheduled_date=None) returns 200."""
+        create_task_db("id-1", "Task 1", "T")  # no scheduled_date — already in backlog
+
+        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1"]})
+
+        assert response.status_code == 200
+        assert response.json()[0]["scheduled_date"] is None

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -226,58 +226,42 @@ class TestSettingsEndpoints:
         assert response.json()["default_priority"] == "none"
 
 
-class TestBulkMoveToBacklog:
-    """Tests for POST /tasks/bulk-move-to-backlog (Issue #66)."""
+class TestMoveToBacklog:
+    """Tests for move-to-backlog via PATCH /tasks/{id} (Issue #66).
 
-    def test_bulk_move_clears_scheduled_date(self, test_db, app_client):
-        """POST with valid IDs sets scheduled_date=None on all specified tasks."""
+    The frontend sends parallel PATCH requests with scheduled_date=null,
+    consistent with bulk-complete and bulk-delete patterns.
+    """
+
+    def test_patch_clears_scheduled_date(self, test_db, app_client):
+        """PATCH with scheduled_date=null moves a task to backlog."""
         create_task_db("id-1", "Task 1", "T", "2026-05-02")
-        create_task_db("id-2", "Task 2", "T", "2026-05-02")
-        create_task_db("id-3", "Task 3", "T", "2026-05-02")
 
-        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1", "id-2"]})
+        response = app_client.patch("/tasks/id-1", json={"scheduled_date": None})
 
         assert response.status_code == 200
-        updated = {t["id"]: t for t in response.json()}
-        assert updated["id-1"]["scheduled_date"] is None
-        assert updated["id-2"]["scheduled_date"] is None
+        assert response.json()["scheduled_date"] is None
 
-    def test_bulk_move_does_not_affect_other_tasks(self, test_db, app_client):
-        """Tasks not in the request are not modified."""
+    def test_patch_does_not_affect_other_tasks(self, test_db, app_client):
+        """Patching one task does not modify others."""
         create_task_db("id-1", "Task 1", "T", "2026-05-02")
         create_task_db("id-2", "Task 2", "T", "2026-05-02")
 
-        app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1"]})
+        app_client.patch("/tasks/id-1", json={"scheduled_date": None})
 
         all_tasks = {t["id"]: t for t in app_client.get("/tasks").json()}
         assert all_tasks["id-2"]["scheduled_date"] == "2026-05-02"
 
-    def test_bulk_move_empty_ids_returns_422(self, app_client):
-        """POST with empty task_ids list returns 422 validation error."""
-        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": []})
-        assert response.status_code == 422
-
-    def test_bulk_move_unknown_id_returns_404(self, app_client):
-        """POST with a non-existent task ID returns 404."""
-        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["ghost-id"]})
+    def test_patch_unknown_id_returns_404(self, app_client):
+        """PATCH with a non-existent task ID returns 404."""
+        response = app_client.patch("/tasks/ghost-id", json={"scheduled_date": None})
         assert response.status_code == 404
 
-    def test_bulk_move_partial_failure_updates_preceding_tasks(self, test_db, app_client):
-        """Valid IDs before an unknown ID are updated; the request returns 404."""
-        create_task_db("id-1", "Task 1", "T", "2026-05-02")
-
-        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1", "ghost-id"]})
-
-        assert response.status_code == 404
-        # id-1 was updated before the 404 — partial write is the current behaviour
-        all_tasks = {t["id"]: t for t in app_client.get("/tasks").json()}
-        assert all_tasks["id-1"]["scheduled_date"] is None
-
-    def test_bulk_move_already_backlogged_task_is_idempotent(self, test_db, app_client):
-        """Moving a task already in the backlog (scheduled_date=None) returns 200."""
+    def test_patch_already_backlogged_task_is_idempotent(self, test_db, app_client):
+        """Patching a task already in the backlog (scheduled_date=None) returns 200."""
         create_task_db("id-1", "Task 1", "T")  # no scheduled_date — already in backlog
 
-        response = app_client.post("/tasks/bulk-move-to-backlog", json={"task_ids": ["id-1"]})
+        response = app_client.patch("/tasks/id-1", json={"scheduled_date": None})
 
         assert response.status_code == 200
-        assert response.json()[0]["scheduled_date"] is None
+        assert response.json()["scheduled_date"] is None

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -427,6 +427,23 @@ body {
   border-color: #8aaae0;
 }
 
+.move-to-backlog-btn {
+  padding: 0.25rem 0.75rem;
+  background: transparent;
+  color: #c9a72a;
+  border: 1px solid #c9a72a;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.move-to-backlog-btn:hover {
+  background: rgba(201, 167, 42, 0.15);
+  color: #e0c44a;
+  border-color: #e0c44a;
+}
+
 .reschedule-popup {
   min-width: 220px;
 }

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { computeColumnLayout, DEFAULT_DURATION, pxToSnappedMinutes, minutesToTimeStr } from '../utils/calendarLayout'
 import { formatTaskCreationDate } from '../utils/date'
+import { moveTasksToBacklog, getMoveToBacklogLabel } from '../utils/taskApi'
 
 interface Task {
   id: string
@@ -178,6 +179,14 @@ function TaskList({ tasks, overdueTasks = [], viewMode, selectedDate, todayStr, 
       x: e.clientX,
       y: e.clientY,
     })
+  }
+
+  async function handleMoveToBacklog() {
+    const ids = Array.from(selectedIds)
+    if (ids.length === 0) return
+    await moveTasksToBacklog(ids, API_URL)
+    setSelectedIds(new Set())
+    onTasksUpdate()
   }
 
   function handleDeleteSelected(e: React.MouseEvent) {
@@ -720,6 +729,11 @@ function TaskList({ tasks, overdueTasks = [], viewMode, selectedDate, todayStr, 
               <button type="button" className="reschedule-selected-btn" onClick={openReschedulePopup}>
                 Reschedule
               </button>
+
+              <button type="button" className="move-to-backlog-btn" onClick={handleMoveToBacklog}>
+                {getMoveToBacklogLabel(selectedIds.size)}
+              </button>
+
               {selectedIds.size > 1 && (
                 <button type="button" className="delete-selected-btn" onClick={handleDeleteSelected}>
                   <TrashIcon /> Delete

--- a/frontend/src/utils/taskApi.test.ts
+++ b/frontend/src/utils/taskApi.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { moveTasksToBacklog, getMoveToBacklogLabel } from './taskApi'
+
+const API_URL = 'http://localhost:8000'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('getMoveToBacklogLabel', () => {
+  it('returns "Move to Backlog" for a single task', () => {
+    expect(getMoveToBacklogLabel(1)).toBe('Move to Backlog')
+  })
+
+  it('returns "Move all to Backlog" for multiple tasks', () => {
+    expect(getMoveToBacklogLabel(2)).toBe('Move all to Backlog')
+    expect(getMoveToBacklogLabel(10)).toBe('Move all to Backlog')
+  })
+})
+
+describe('moveTasksToBacklog', () => {
+  it('sends PATCH with scheduled_date=null for each id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await moveTasksToBacklog(['id-1', 'id-2'], API_URL)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledWith(`${API_URL}/tasks/id-1`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scheduled_date: null }),
+    })
+    expect(fetchMock).toHaveBeenCalledWith(`${API_URL}/tasks/id-2`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scheduled_date: null }),
+    })
+  })
+
+  it('makes all requests in parallel (Promise.all)', async () => {
+    const order: string[] = []
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      order.push(url)
+      return Promise.resolve({ ok: true })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await moveTasksToBacklog(['id-a', 'id-b', 'id-c'], API_URL)
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('resolves with empty array when no ids provided', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await moveTasksToBacklog([], API_URL)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('throws when the server returns a non-ok response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(moveTasksToBacklog(['id-1'], API_URL)).rejects.toThrow('404')
+  })
+})

--- a/frontend/src/utils/taskApi.ts
+++ b/frontend/src/utils/taskApi.ts
@@ -1,0 +1,14 @@
+export function getMoveToBacklogLabel(count: number): string {
+  return count > 1 ? 'Move all to Backlog' : 'Move to Backlog'
+}
+
+export async function moveTasksToBacklog(ids: string[], apiUrl: string): Promise<void> {
+  await Promise.all(ids.map(async id => {
+    const res = await fetch(`${apiUrl}/tasks/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scheduled_date: null }),
+    })
+    if (!res.ok) throw new Error(String(res.status))
+  }))
+}


### PR DESCRIPTION
Closes #66.

## Summary
- Added "Move to Backlog" button to the day-view-actions bar (alongside Reschedule and Delete); label reads "Move all to Backlog" when 2+ tasks are selected.
- Move-to-backlog uses parallel `PATCH /tasks/{id}` with `{ scheduled_date: null }`, consistent with bulk-complete and bulk-delete. No new endpoint — an earlier `POST /tasks/bulk-move-to-backlog` was dropped after review flagged it as dead code.
- Extracted `moveTasksToBacklog` and `getMoveToBacklogLabel` into `src/utils/taskApi.ts` for testability.

## Screenshot

<img width="783" height="401" alt="Screen Shot 2026-05-09 at 1 39 26 PM" src="https://github.com/user-attachments/assets/9e98e70b-1acd-43c8-929c-b4160695ffc8" />

## Test plan
- [x] `pytest tests/unit/` — all passing
- [x] `pnpm test` — all passing
- [x] Manually verify: select one task in day view → "Move to Backlog" button appears; task disappears from day view and appears in backlog tab
- [x] Manually verify: select multiple tasks → button reads "Move all to Backlog"; all tasks move to backlog

## Checklist
- [x] All existing tests pass
- [x] New tests added for new behavior (if applicable)
- [x] Docs updated (if applicable) — no docs changes needed
- [x] No unrelated changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)